### PR TITLE
Update the version of LalrPop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poreader"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 description = "Read translation catalogs in PO format."
 authors = ["Frédéric Meyer <frederic.meyer.77@gmail.com>"]
@@ -16,9 +16,9 @@ travis-ci = { repository = "coreabreaker/poreader" }
 appveyor = { repository = "coreabreaker/poreader" }
 
 [build-dependencies]
-lalrpop = "~0.19.6"
+lalrpop = "~0.19.7"
 
 [dependencies]
-lalrpop-util = { version = "~0.19.6", features = ["lexer"] }
+lalrpop-util = { version = "~0.19.7", features = ["lexer"] }
 locale_config = "^0.3.0"
 regex = "^1.5.4"

--- a/src/plural/formula/formula.lalrpop
+++ b/src/plural/formula/formula.lalrpop
@@ -6,8 +6,7 @@ extern {
     type Error = String;
 }
 
-// TODO with lalrpop 0.19.7: pub(in crate::plural::formula) Formula = Expr;
-pub(crate) Formula = Expr;
+pub(in crate::plural::formula) Formula = Expr;
 
 Expr: Node = {
     <test:Or> "?" <if_true:Expr> ":" <if_false:Expr> => Node::new_cond(test, if_true, if_false),


### PR DESCRIPTION
LalrPop changed its version (0.19.6 -> 0.19.7). The main interest is for defining the visibility of the main symbol for having a rightly scoped parser.